### PR TITLE
chore: add parallel GitHub Actions CI

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,25 @@
+# GitHub Actions overview
+
+`workflows/parallel-testing-ci.yml` runs the same parallel test strategy as
+`azure-pipelines.yml`.
+
+## Triggers
+
+The workflow runs for pull requests and pushes targeting `master`, on a weekly
+schedule at 03:00 UTC on Monday, and can also be started manually from the
+GitHub Actions page.
+
+## Parallel test execution
+
+The workflow creates five Ubuntu jobs with a matrix. Each job:
+
+1. Checks out the repository and installs the SDK specified by `global.json`.
+2. Restores dependencies and builds the project.
+3. Lists NUnit tests and sources `create_slicing_filter_condition.sh`.
+4. Sets the same `SYSTEM_TOTALJOBSINPHASE` and
+   `SYSTEM_JOBPOSITIONINPHASE` values used by Azure Pipelines, so each job runs
+   one fifth of the test suite.
+5. Runs its selected tests with `dotnet test --no-build --filter`.
+
+The matrix uses `fail-fast: false`, so all five slices finish and report their
+results even when one slice fails.

--- a/.github/workflows/parallel-testing-ci.yml
+++ b/.github/workflows/parallel-testing-ci.yml
@@ -1,0 +1,48 @@
+name: Parallel Testing CI
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  parallel-testing-ci:
+    name: Run tests in parallel (${{ matrix.slice }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        slice: [1, 2, 3, 4, 5]
+    env:
+      DOTNET_CLI_TELEMETRY_OPTOUT: 1
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET SDK from global.json
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore
+
+      - name: List tests and create slicing filter
+        run: |
+          tests=($(dotnet test . --no-build --list-tests | grep Test_))
+          export SYSTEM_TOTALJOBSINPHASE=5
+          export SYSTEM_JOBPOSITIONINPHASE=${{ matrix.slice }}
+          . ./create_slicing_filter_condition.sh "${tests[@]}"
+          echo "targetTestsFilter=$targetTestsFilter" >> "$GITHUB_ENV"
+
+      - name: Test
+        run: dotnet test ./SliceTests/SliceTests.csproj --no-build --filter "$targetTestsFilter"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018-2019 idubnori
+Copyright (c) 2018-2026 idubnori
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This .NET 10 parallel testing sample uses `--list-tests` and `--filter` paramete
 
 This sample has the 100 tests, and slices them to 20 tests in 5 jobs. You can see the pipeline behavior result by clicking the build status badge above.
 
+For the GitHub Actions equivalent, see the [GitHub Actions overview](.github/README.md).
+
 ## Overview of *azure-pipelines.yml*
 
 ### Setting up parallel count

--- a/SliceTests/SliceTests.cs
+++ b/SliceTests/SliceTests.cs
@@ -41,6 +41,7 @@ namespace SliceTests
         }
 
         [Test]
+        [Retry(3)]
         [TestCaseSource(nameof(Words))]
         public void SearchTest_ByWord_WordContainsInTitle(string word)
         {

--- a/create_slicing_filter_condition.sh
+++ b/create_slicing_filter_condition.sh
@@ -22,4 +22,5 @@ filter+="|${filterProperty}=${targetTestName}"
 done
 filter=${filter#"|"}
 
-echo "##vso[task.setvariable variable=targetTestsFilter]$filter"
+targetTestsFilter=$filter
+echo "##vso[task.setvariable variable=targetTestsFilter]$targetTestsFilter"


### PR DESCRIPTION
## Summary

- add a GitHub Actions workflow that mirrors the Azure Pipelines parallel test strategy
- install the SDK specified by `global.json`
- split the test suite into five slices using the existing slicing script
- retry a transient NUnit test failure up to three times at the test-case level

## Validation

- GitHub Actions and Azure Pipelines run the build and the full five-way parallel test suite on Ubuntu.