### PR TITLE
Upgrade to .NET 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,6 @@ This .NET 10 parallel testing sample uses `--list-tests` and `--filter` paramete
 This sample has the 100 tests, and slices them to 20 tests in 5 jobs. You can see the pipeline behavior result by clicking the build status badge above.
 
 ## Overview of *azure-pipelines.yml*
-### Selecting the SDK
-```yml
-  - task: UseDotNet@2
-    displayName: 'Use .NET SDK from global.json'
-    inputs:
-      useGlobalJson: true
-```
 
 ### Setting up parallel count
 ```yml

--- a/README.md
+++ b/README.md
@@ -3,11 +3,19 @@ ParallelTestingSample-dotnet-core
 [![GitHub license](https://img.shields.io/github/license/idubnori/ParallelTestingSample-dotnet-core.svg)](https://github.com/idubnori/ParallelTestingSample-dotnet-core/blob/master/LICENSE)
 [![Build Status](https://dev.azure.com/idubnori/idubnori/_apis/build/status/ParallelTestingSample-dotnet-CI)](https://dev.azure.com/idubnori/idubnori/_build/latest?definitionId=4)
 
-This .NET Core parallel testing sample uses `--list-tests` and `--filter` parameters of `dotnet test` to slice the tests. The tests are run using the NUnit.
+This .NET 10 parallel testing sample uses `--list-tests` and `--filter` parameters of `dotnet test` to slice the tests. The tests are run using the NUnit.
 
 This sample has the 100 tests, and slices them to 20 tests in 5 jobs. You can see the pipeline behavior result by clicking the build status badge above.
 
 ## Overview of *azure-pipelines.yml*
+### Selecting the SDK
+```yml
+  - task: UseDotNet@2
+    displayName: 'Use .NET SDK from global.json'
+    inputs:
+      useGlobalJson: true
+```
+
 ### Setting up parallel count
 ```yml
 jobs:

--- a/SliceTests/SliceTests.csproj
+++ b/SliceTests/SliceTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,18 +16,15 @@ jobs:
 
   steps:
   - task: UseDotNet@2
-    displayName: 'Use .NET sdk 8.0.x'
+    displayName: 'Use .NET SDK from global.json'
     inputs:
-      version: 8.0.x
       useGlobalJson: true
-      performMultiLevelLookup: true
       
   - task: DotNetCoreCLI@2
     displayName: Build
     inputs:
       command: build
       projects: '**/*.csproj'
-      useGlobalJson: true
 
   - bash: |
       tests=($(dotnet test . --no-build --list-tests | grep Test_))
@@ -43,5 +40,4 @@ jobs:
     inputs:
       command: test
       projects: '**/*Tests/*Tests.csproj'
-      useGlobalJson: true
       arguments: '--no-build --filter "$(targetTestsFilter)"'

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "10.0.100",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
## Summary

- target .NET 10 (`net10.0`) and select SDK 10.0.100 from `global.json`
- simplify Azure Pipelines SDK selection to use `global.json`
- remove unsupported or irrelevant Azure Pipelines task inputs
- update the README to describe .NET 10 setup

## Why

The repository was pinned to .NET 8. This updates it to .NET 10 LTS while keeping the existing test execution and slicing behavior unchanged.

## Validation

- Local `dotnet restore`, build, and test were intentionally not run.
- Azure Pipelines CI is the validation authority for this change.