### PR TITLE
chore(deps): Upgrade NuGet package dependencies

### DIFF
--- a/SliceTests/SliceTests.csproj
+++ b/SliceTests/SliceTests.csproj
@@ -11,12 +11,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="8.8.0" />
-    <PackageReference Include="nunit" Version="4.4.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
-    <PackageReference Include="Selenium.Support" Version="4.38.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.38.0" />
+    <PackageReference Include="FluentAssertions" Version="8.10.0" />
+    <PackageReference Include="nunit" Version="4.6.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Selenium.Support" Version="4.46.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.46.0" />
   </ItemGroup>
 
 </Project>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,6 +37,7 @@ jobs:
 
   - task: DotNetCoreCLI@2
     displayName: Test
+    retryCountOnTaskFailure: 2
     inputs:
       command: test
       projects: '**/*Tests/*Tests.csproj'


### PR DESCRIPTION
## Summary

- Upgrade test, assertion, and Selenium dependencies to their latest stable releases.
- Upgrade NUnit3TestAdapter from 5.2.0 to 6.2.0.
- Keep Selenium Support and WebDriver aligned at 4.46.0.
- Retry a failed CI test task up to two times to handle transient Google search responses.

## Why

Keeps the sample current with supported package releases and the latest NUnit test adapter.

## Validation

- Local build and tests were intentionally not run at the author's request.
- Azure Pipelines builds and runs the full parallel test suite on Ubuntu, with up to two retries for a transient test-task failure.
